### PR TITLE
feat: :sparkles: Add JanAPI integration for local LLMs

### DIFF
--- a/addons/ai_assistant_hub/ai_hub_plugin.gd
+++ b/addons/ai_assistant_hub/ai_hub_plugin.gd
@@ -90,5 +90,13 @@ func get_available_llm_providers() -> Array[Dictionary]:
 		"name": "OpenRouter",
 		"description": "Unified interface to access various commercial LLMs (requires API key)"
 	})
+
+	# Add Jan.IA provider
+	providers.append({
+		"id":"jan_api",
+		"name":"Jan",
+		"description":"Locally run open source LLMs models (requires Jan’s OpenAI‑compatible server)"
+	})
+
 	
 	return providers

--- a/addons/ai_assistant_hub/llm_apis/jan_api.gd
+++ b/addons/ai_assistant_hub/llm_apis/jan_api.gd
@@ -1,0 +1,57 @@
+@tool
+class_name JanAPI
+extends LLMInterface
+
+const HEADERS := ["Content-Type: application/json"]
+
+func send_get_models_request(http_request: HTTPRequest) -> bool:
+    var base := ProjectSettings.get_setting(AIHubPlugin.CONFIG_BASE_URL)
+    var url := "%s/v1/models" % base
+    var err := http_request.request(url, HEADERS, HTTPClient.METHOD_GET)
+    if err != OK:
+        push_error("JanAPI GET models failed: %s" % url)
+        return false
+    return true
+
+func read_models_response(body: PackedByteArray) -> Array[String]:
+    var j := JSON.new()
+    j.parse(body.get_string_from_utf8())
+    var data := j.get_data()
+    if data.has("data") and data.data is Array:
+        var out := []
+        for m in data.data:
+            if m.has("id"):
+                out.append(m.id)
+        out.sort()
+        return out
+    return [INVALID_RESPONSE]
+
+func send_chat_request(http_request: HTTPRequest, content: Array) -> bool:
+    if model.is_empty():
+        push_error("JanAPI: no model set!")
+        return false
+    var body := {
+        "model": model,
+        "messages": content
+    }
+    if override_temperature:
+        body["temperature"] = temperature
+    var payload := JSON.new().stringify(body)
+    var base := ProjectSettings.get_setting(AIHubPlugin.CONFIG_BASE_URL)
+    var url := "%s/v1/chat/completions" % base
+    var err := http_request.request(url, HEADERS, HTTPClient.METHOD_POST, payload)
+    if err != OK:
+        push_error("JanAPI chat request failed: %s\n%s" % [url, payload])
+        return false
+    return true
+
+func read_response(body: PackedByteArray) -> String:
+    var j := JSON.new()
+    j.parse(body.get_string_from_utf8())
+    var data := j.get_data()
+    if data.has("choices") and data.choices.size() > 0:
+        var c = data.choices[0]
+        if c.has("message") and c.message.has("content"):
+            return c.message.content
+    return INVALID_RESPONSE
+ 


### PR DESCRIPTION
#  Add JanAPI integration for local LLMs

## Feature Description

This changes will allow the user to use locally deployed LLM models using the free and open source tool [Jan.AI](https://jan.ai/), this tool allow the users to create a local servers very similar to OpenAI API, this PR centers on adding the necessary support to integrate Jan models in Godot AI Assistant Hub Plugin.

## Motivation

Have a fully local/self-hosted, free and open source assistant available in Godot v4 directly.

## Tested on

S.O: Windows 10 Pro build 19045.5737
Hardware: Lenovo ThinkPad L14 Gen1 AMD Ryzen 3 Pro 4450U with Radeon Graphics (2Gb shared VRAM), 16Gb of DDR4 RAM.
Relevant Software:
- Godot v4.4 Stable
- Jan v0.5.16
- Model: [qwen2.5-coder-0.5b-instruct-q8_0](https://huggingface.co/Qwen/Qwen2.5-Coder-0.5B-Instruct-GGUF)

Note: only simple request where tested (like creating code-based state machines or simple refactors for already existing scripts, nothing major)

## Changelog

- Implemented `JanAPI` class in `jan_api.gd` to support locally run open source LLMs. 
- Added methods for sending requests and reading responses for model retrieval and chat completions. 
- Updated `AIHubPlugin` to include JanAPI as an available LLM provider.