### PR TITLE
Fix minor spelling error in chat history editor dialog

### DIFF
--- a/addons/ai_assistant_hub/chat_history_editor.tscn
+++ b/addons/ai_assistant_hub/chat_history_editor.tscn
@@ -6,7 +6,7 @@
 bg_color = Color(0.21, 0.24, 0.29, 1)
 
 [node name="ChatHistoryEditor" type="Window"]
-title = "Chat hisotry editor"
+title = "Chat history editor"
 initial_position = 2
 size = Vector2i(800, 600)
 exclusive = true


### PR DESCRIPTION
"hisotry" -> "history". This is a user-facing string so worth a quick PR.