### PR TITLE
Add button to UI to abandon current response generation

### DIFF
--- a/addons/ai_assistant_hub/ai_chat.tscn
+++ b/addons/ai_assistant_hub/ai_chat.tscn
@@ -1,10 +1,15 @@
-[gd_scene load_steps=6 format=3 uid="uid://c5d12f133cpv7"]
+[gd_scene load_steps=8 format=3 uid="uid://c5d12f133cpv7"]
 
 [ext_resource type="Script" path="res://addons/ai_assistant_hub/ai_chat.gd" id="1_v0kvm"]
 [ext_resource type="Texture2D" uid="uid://beq5nk70uk8v4" path="res://addons/ai_assistant_hub/graphics/icons/edit_chat_icon.png" id="2_8urns"]
 [ext_resource type="PackedScene" uid="uid://dxr0f1xqsje6b" path="res://addons/ai_assistant_hub/bot_portrait.tscn" id="3_lcoap"]
 [ext_resource type="AudioStream" uid="uid://dk1yumltykf6x" path="res://addons/ai_assistant_hub/sounds/ai_replied.wav" id="4_7y76u"]
+[ext_resource type="Texture2D" uid="uid://qjvopjqelt0m" path="res://addons/ai_assistant_hub/graphics/icons/linear_32_3dmsicons.png" id="4_11xim"]
 [ext_resource type="AudioStream" uid="uid://b2lftlbs848c4" path="res://addons/ai_assistant_hub/sounds/ai_error_cancel.wav" id="5_mmsii"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_glvco"]
+atlas = ExtResource("4_11xim")
+region = Rect2(416.097, 735.908, 31.3832, 32.4435)
 
 [node name="AIChat" type="Control"]
 clip_contents = true
@@ -111,6 +116,27 @@ grow_horizontal = 2
 grow_vertical = 0
 mouse_filter = 2
 
+[node name="BotCancel" type="Button" parent="HBoxContainer/VBoxContainer/VSplitContainer/HBoxContainer/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -4.0
+offset_top = -71.0
+offset_right = 35.0
+offset_bottom = -31.0
+grow_horizontal = 2
+grow_vertical = 0
+scale = Vector2(0.7, 0.7)
+size_flags_vertical = 0
+tooltip_text = "Stop thinking"
+icon = SubResource("AtlasTexture_glvco")
+flat = true
+icon_alignment = 1
+
 [node name="HBoxContainer2" type="HBoxContainer" parent="HBoxContainer/VBoxContainer/VSplitContainer"]
 layout_mode = 2
 
@@ -190,6 +216,7 @@ stream = ExtResource("5_mmsii")
 [connection signal="request_completed" from="HTTPRequest" to="." method="_on_http_request_completed"]
 [connection signal="pressed" from="HBoxContainer/VBoxContainer/VSplitContainer/HBoxContainer/MarginContainer/EditHistory" to="." method="_on_edit_history_pressed"]
 [connection signal="toggled" from="HBoxContainer/VBoxContainer/VSplitContainer/HBoxContainer/MarginContainer/AutoScrollCheckBox" to="." method="_on_auto_scroll_check_box_toggled"]
+[connection signal="pressed" from="HBoxContainer/VBoxContainer/VSplitContainer/HBoxContainer/MarginContainer/BotCancel" to="." method="_abandon_request"]
 [connection signal="toggled" from="HBoxContainer/VBoxContainer/HBoxContainer/TemperatureOverrideCheckbox" to="." method="_on_temperature_override_checkbox_toggled"]
 [connection signal="value_changed" from="HBoxContainer/VBoxContainer/HBoxContainer/TemperatureSliderContainer/TemperatureSlider" to="." method="_on_temperature_slider_value_changed"]
 [connection signal="item_selected" from="HBoxContainer/VBoxContainer/HBoxContainer/ModelOptionsBtn" to="." method="_on_model_options_btn_item_selected"]

--- a/addons/ai_assistant_hub/bot_portrait.gd
+++ b/addons/ai_assistant_hub/bot_portrait.gd
@@ -11,6 +11,7 @@ const SCALE := 3 # given the images are 16px but we are displaying them 48px, th
 @onready var portrait_mouth: TextureRect = %PortraitMouth
 @onready var portrait_eyes: TextureRect = %PortraitEyes
 @onready var portrait_thinking: TextureRect = %PortraitThinking
+@onready var bot_cancel: Button = %BotCancel
 
 var _think_tween:Tween
 
@@ -36,6 +37,7 @@ var is_thinking:= false:
 		if _think_tween != null and _think_tween.is_running():
 			_think_tween.stop()
 		portrait_thinking.visible = is_thinking
+		bot_cancel.visible = is_thinking
 		if is_thinking:
 			portrait_eyes.position.x = SCALE
 			portrait_eyes.position.y = -SCALE


### PR DESCRIPTION
Add button to abort current response generation (simply calling existing method `_abandon_request()` that's not easily identifiable to the average user).
![image](https://github.com/user-attachments/assets/7d572034-ac31-40dd-ac21-6e5d47377007)


Use case: I tried using qwen3-moe which turned out to be really slow on my machine and I had no idea how to interrupt the response. I did end up finding the _abandon_request() method, but that was after several times waiting a minute or so for it to come back. I found in the script that a prompt can interrupt a response in the same way, but this is hopefully a slight UX improvement for the average user who may not go looking for that.

Possible improvement can be made to the visuals, or even combine the action with the thinking icon itself (probably with a tooltip such as "click to stop thinking").