### PR TITLE
fix typo in error message and toggle assistant tabs draggable

### DIFF
--- a/addons/ai_assistant_hub/ai_assistant_hub.tscn
+++ b/addons/ai_assistant_hub/ai_assistant_hub.tscn
@@ -36,6 +36,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 current_tab = 0
+drag_to_rearrange_enabled = true
 
 [node name="AI Hub" type="MarginContainer" parent="VBoxContainer/TabContainer"]
 layout_mode = 2

--- a/addons/ai_assistant_hub/llm_apis/ollama_api.gd
+++ b/addons/ai_assistant_hub/llm_apis/ollama_api.gd
@@ -8,7 +8,7 @@ const HEADERS := ["Content-Type: application/json"]
 func send_get_models_request(http_request:HTTPRequest) -> bool:
 	var error = http_request.request(_models_url, HEADERS, HTTPClient.METHOD_GET)
 	if error != OK:
-		push_error("Something when wrong with last AI API call: %s" % _models_url)
+		push_error("Something went wrong with last AI API call: %s" % _models_url)
 		return false
 	return true
 
@@ -45,7 +45,7 @@ func send_chat_request(http_request:HTTPRequest, content:Array) -> bool:
 	
 	var error = http_request.request(_chat_url, HEADERS, HTTPClient.METHOD_POST, body)
 	if error != OK:
-		push_error("Something when wrong with last AI API call.\nURL: %s\nBody:\n%s" % [_chat_url, body])
+		push_error("Something went wrong with last AI API call.\nURL: %s\nBody:\n%s" % [_chat_url, body])
 		return false
 	return true
 

--- a/addons/ai_assistant_hub/llm_apis/ollamaturbo_api.gd
+++ b/addons/ai_assistant_hub/llm_apis/ollamaturbo_api.gd
@@ -13,7 +13,7 @@ func _initialize() -> void:
 func send_get_models_request(http_request:HTTPRequest) -> bool:
 	var error = http_request.request(_models_url, _headers, HTTPClient.METHOD_GET)
 	if error != OK:
-		push_error("Something when wrong with last AI API call: %s" % _models_url)
+		push_error("Something went wrong with last AI API call: %s" % _models_url)
 		return false
 	return true
 
@@ -50,7 +50,7 @@ func send_chat_request(http_request:HTTPRequest, content:Array) -> bool:
 	
 	var error = http_request.request(_chat_url, _headers, HTTPClient.METHOD_POST, body)
 	if error != OK:
-		push_error("Something when wrong with last AI API call.\nURL: %s\nBody:\n%s" % [_chat_url, body])
+		push_error("Something went wrong with last AI API call.\nURL: %s\nBody:\n%s" % [_chat_url, body])
 		return false
 	return true
 

--- a/addons/ai_assistant_hub/llm_apis/openwebui_api.gd
+++ b/addons/ai_assistant_hub/llm_apis/openwebui_api.gd
@@ -19,7 +19,7 @@ func send_get_models_request(http_request:HTTPRequest) -> bool:
 	
 	var error = http_request.request(_models_url, _headers, HTTPClient.METHOD_GET)
 	if error != OK:
-		push_error("Something when wrong with last AI API call: %s" % _models_url)
+		push_error("Something went wrong with last AI API call: %s" % _models_url)
 		return false
 	return true
 
@@ -60,7 +60,7 @@ func send_chat_request(http_request:HTTPRequest, content:Array) -> bool:
 	
 	var error = http_request.request(_chat_url, _headers, HTTPClient.METHOD_POST, body)
 	if error != OK:
-		push_error("Something when wrong with last AI API call.\nURL: %s\nBody:\n%s" % [_chat_url, body])
+		push_error("Something went wrong with last AI API call.\nURL: %s\nBody:\n%s" % [_chat_url, body])
 		return false
 	return true
 


### PR DESCRIPTION
I found this plugin about ~48 hrs ago and immediately fell in love with it! :)

I saw this spelling mistake in an error message on my initial setup with Ollama, so I went ahead and fixed it in all the API files.

I also went ahead and toggled the assistant tabs in the Hub to be draggable / re-arrangable, since it's such a simple quality of life update. (This is my first pull request ever... maybe I should have separated those into separate branches?)

Tested and working with no issues in 4.3, 4.4 and 4.5