### PR TITLE
Define the return datatype as Array[String] instead of Array[]

### DIFF
--- a/addons/ai_assistant_hub/llm_apis/jan_api.gd
+++ b/addons/ai_assistant_hub/llm_apis/jan_api.gd
@@ -18,7 +18,7 @@ func read_models_response(body: PackedByteArray) -> Array[String]:
 	j.parse(body.get_string_from_utf8())
 	var data := j.get_data()
 	if data.has("data") and data.data is Array:
-		var out := []
+		var out: Array[String]= []
 		for m in data.data:
 			if m.has("id"):
 				out.append(m.id)


### PR DESCRIPTION
It seems that was overlooked, I fixed it.
Without the fix the Jan provider doesn't work because of the broken type expectation.