### PR TITLE
V 1.8.1 - Fix freeze bug, make floating (commented), auto-focus chat, fix bugs in selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **Godot AI Assistant Hub**
 <img src="https://github.com/FlamxGames/godot-ai-assistant-hub/blob/main/logo.png" width="50px">
 ==========================
-**Latest version: 1.8.0**
+**Latest version: 1.8.1**
 <sub>([What's new?](#whats-new-in-the-latest-version))</sub>
 <sub>([Upgrading to a newer version](#upgrading-to-a-newer-version))</sub>
 
@@ -68,8 +68,6 @@ There are 2 main concepts for this addon, familiarize yourself with them, both a
 #### A) AI assistant type (AIAssistantResource). 🤖
 This is the setup for an assistant, it describes what the assistant does, what LLM model to use, and what Quick Prompts it can use.
 
-<Insert an image>
-
 Think of it as a template for creating assistants. For example, you can have an assistant that helps with coding, and one that helps with writing. In that case, you would have 2 assistant types, and you can summon as many coders or writers you need.
 
 #### B) Quick Prompt (AIQuickPromptResource). 🪄
@@ -78,7 +76,12 @@ The following keywords are used to allow the prompt to pull data from the Code E
 * Use `{CODE}` to insert the code currently selected in the editor.
 * Use `{CHAT}` to include the current content of the text prompt.
 
-<Insert an image>
+**Note**: Most models already tag their code properly, but not all of them. In order for the plugin to identify what code to use from the assistant's response, you may need to give explicit instructions in their description, for example:
+
+    Any code you write you mark it properly, for example:
+    ```gdscript
+    var x:String = "abc"
+    ```
 
 ## Setup steps
 In general this is what you need to do:
@@ -91,7 +94,7 @@ In general this is what you need to do:
 5. You should see a list of models you have installed. Click one and use the "New assistant type" button.
 6. Fill up the data for your assistant.
 7. After saving, you should see a new button for your assistant type.
-8. Your assistant type will open in the Inspector panel, there you can optionally confirgure an icon and Quick Prompts for your assistant type, the later would allow it to interact with the code editor.
+8. Your assistant type will open in the Inspector panel, there you can optionally configure an icon and Quick Prompts for your assistant type, the later would allow it to interact with the code editor.
 9. Click the assistant type button to start a chat with a new assistant of this type.
 
 ### Configuring Quick Prompts and icon ###
@@ -115,18 +118,19 @@ Experiment and build the right type of assistants for your workflow.
 
 ### Not sure what models to use?
 
-Some popular models that work fine in low-end computers at the time I wrote this (Oct 2024) are:
-* **llama3.2:** Fast and efficient, but may have occasional accuracy issues.
-* **granite-code:** Ideal for coding on lower-end machines.
-* **mistral:** Excellent for writing tasks.
-* **deepseek-coder-v2:** Powerful coding model (requires at least 8GB of VRAM).
+I found it is not a good idea to give advice here, as models change all the time. What I suggest you to do is to search “Best coding local LLM models in (current year) that fit (insert your setup here).”
+For example, “Best coding local LLM models in 2026 that fit 8 GB of VRAM.”
 
-⚠️ If you don't agree with these suggestions or have an updated list of recommendations, leave a comment in the Discussions page with your suggestions.
-
-If you have a powerful PC, just keep increasing the level of the model. You will see many models have versions like 1.5B, 3B, 7B, 30B, 77B, these mean billions of parameters. You can consider 1.5B for very low-end machines, and 77B for very powerful ones. If you are not sure, just try them out, they are easy to delete as well.
+The rule of thumb I follow is to check the output speed by chatting with it. If it is slow, the model is not being loaded onto my GPU; it is using RAM/CPU. You probably only want to do that if the results the model produces are remarkably better, or simply if you don’t have a GPU capable of loading any models.
 
 **What's new in the latest version**
 -----------------------
+**1.8.1**
+* When you select an assistant tab, the chat text box is now focused automatically.
+* Added commented code in ai_hub_plugin.gd under _enter_tree() and _exit_tree(), in Godot 4.6 you can uncomment this to enable making the plugin screen floating by right-clicking its tab.
+* Fixed bugs in code placement when replacing the selection. Also improved code placement in general removing extra lines around it.
+* Fixed bug that caused freeze when editing an assistant resource in Linux.
+
 **1.8.0**
 * xAI API support
 
@@ -156,4 +160,4 @@ I'm a solo game developer that sometimes ends up building game dev tools. This a
 
 **License**
 ----------
-This project is licensed under the MIT license. Enjoy!
+This project is licensed under the MIT license.

--- a/addons/ai_assistant_hub/ai_assistant_hub.gd
+++ b/addons/ai_assistant_hub/ai_assistant_hub.gd
@@ -37,6 +37,7 @@ func _tab_changed(tab_index: int) -> void:
 			_tab_bar.tab_close_display_policy = TabBar.CLOSE_BUTTON_SHOW_NEVER
 		else:
 			_tab_bar.tab_close_display_policy = TabBar.CLOSE_BUTTON_SHOW_ACTIVE_ONLY
+		chat.focus_prompt()
 	else:
 		_tab_bar.tab_close_display_policy = TabBar.CLOSE_BUTTON_SHOW_NEVER
 

--- a/addons/ai_assistant_hub/ai_assistant_hub.tscn
+++ b/addons/ai_assistant_hub/ai_assistant_hub.tscn
@@ -255,7 +255,7 @@ theme_override_constants/separation = -8
 [node name="VersionLabel" type="Label" parent="VBoxContainer/TabContainer/AI Hub/VBoxContainer/GridContainer/AdvancedSettings/HBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "v1.8.0"
+text = "v1.8.1"
 horizontal_alignment = 2
 
 [node name="UpgradeBtn" type="Button" parent="VBoxContainer/TabContainer/AI Hub/VBoxContainer/GridContainer/AdvancedSettings/HBoxContainer/HBoxContainer"]

--- a/addons/ai_assistant_hub/ai_chat.gd
+++ b/addons/ai_assistant_hub/ai_chat.gd
@@ -444,3 +444,7 @@ func _on_conversation_chat_appended(new_entry:Dictionary) -> void:
 			var current_chat:Array = config.get_value("chat","entries", [])
 			current_chat.append(new_entry)
 			config.save(_chat_save_path)
+
+
+func focus_prompt() -> void:
+	prompt_txt.grab_focus()

--- a/addons/ai_assistant_hub/ai_hub_plugin.gd
+++ b/addons/ai_assistant_hub/ai_hub_plugin.gd
@@ -15,13 +15,29 @@ const DEPRECATED_CONFIG_GEMINI_API_KEY := "plugins/ai_assistant_hub/gemini_api_k
 const DEPRECATED_CONFIG_OPENWEBUI_API_KEY := "plugins/ai_assistant_hub/openwebui_api_key"
 
 var _hub_dock:AIAssistantHub
+var _dock #Not giving type EditorDock to keep this compatible with versions older than 4.6
 
 func _enter_tree() -> void:
 	initialize_project_settings()
 	_hub_dock = load("res://addons/ai_assistant_hub/ai_assistant_hub.tscn").instantiate()
 	_hub_dock.initialize(self)
-	add_control_to_bottom_panel(_hub_dock, "AI Hub")
-	#add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_UL, _hub_dock)
+	
+	#----------------------------#
+	# Uncomment this in Godot 4.6+. I'm not making this default as EditorDock is experimental, and want to keep compatibility with olver versions.
+	# Make sure to ALSO uncomment the similar marked code below in _exit_tree() function.
+	# Once both are uncommented, reload the plugin, now you could right click the AI Hub tab (the one at the bottom) to make it floating.
+	#----------------------------#
+	#_dock = EditorDock.new()
+	#_dock.title = "AI Hub"
+	#_dock.default_slot = EditorDock.DOCK_SLOT_BOTTOM
+	#_dock.set_available_layouts(EditorDock.DOCK_LAYOUT_HORIZONTAL | EditorDock.DOCK_LAYOUT_FLOATING);
+	#_dock.add_child(_hub_dock)
+	#add_dock(_dock)
+	#_dock.open()
+	#----------------------------#
+	
+	if not _dock:
+		add_control_to_bottom_panel(_hub_dock, "AI Hub")
 
 
 func initialize_project_settings() -> void:
@@ -83,8 +99,15 @@ func initialize_project_settings() -> void:
 
 
 func _exit_tree() -> void:
-	remove_control_from_bottom_panel(_hub_dock)
-	#remove_control_from_docks(_hub_dock)
+	if _dock:
+		#----------------------------#
+		# Uncomment this in Godot 4.6
+		#----------------------------#
+		#remove_dock(_dock)
+		#----------------------------#
+		pass
+	else:
+		remove_control_from_bottom_panel(_hub_dock)
 	_hub_dock.queue_free()
 
 

--- a/addons/ai_assistant_hub/new_ai_assistant_button.gd
+++ b/addons/ai_assistant_hub/new_ai_assistant_button.gd
@@ -58,11 +58,12 @@ func _on_gui_input(event: InputEvent) -> void:
 
 
 func _on_popup_menu_id_pressed(id: int) -> void:
+	# Using big numbers because Godot sometimes have bugs giving default values based on position
 	match id:
-		1:  #  Edit
+		100:  #  Edit
 			var res = ResourceLoader.load(_assistant_type_path)
 			EditorInterface.edit_resource(res)
-		2:  # Delete
+		200:  # Delete
 			confirmation_dialog.show()
 
 

--- a/addons/ai_assistant_hub/new_ai_assistant_button.tscn
+++ b/addons/ai_assistant_hub/new_ai_assistant_button.tscn
@@ -14,10 +14,11 @@ position = Vector2i(6, 26)
 size = Vector2i(71, 66)
 item_count = 3
 item_0/text = "Edit"
-item_0/id = 1
+item_0/id = 100
+item_1/id = 1
 item_1/separator = true
 item_2/text = "Delete"
-item_2/id = 2
+item_2/id = 200
 
 [node name="ConfirmationDialog" type="ConfirmationDialog" parent="."]
 unique_name_in_owner = true

--- a/addons/ai_assistant_hub/plugin.cfg
+++ b/addons/ai_assistant_hub/plugin.cfg
@@ -3,5 +3,5 @@
 name="AI Assistant Hub"
 description="Embed AI assistants in Godot with the ability to read and write code in Godot's Code Editor."
 author="Flamx Games"
-version="1.8.0"
+version="1.8.1"
 script="ai_hub_plugin.gd"

--- a/addons/ai_assistant_hub/tools/assistant_tool_code_writer.gd
+++ b/addons/ai_assistant_hub/tools/assistant_tool_code_writer.gd
@@ -13,22 +13,26 @@ func _init(plugin:EditorPlugin, code_selector:AssistantToolSelection) -> void:
 func write_to_code_editor(text_answer:String, code_placement:AIQuickPromptResource.CodePlacement) -> bool:
 	var select_success := _code_selector.back_to_selection()
 	if select_success:
-		var script_editor := _plugin.get_editor_interface().get_script_editor().get_current_editor()
+		var script_editor := EditorInterface.get_script_editor().get_current_editor()
 		var code_editor = script_editor.get_base_editor()
 		var start_line:int = code_editor.get_selection_from_line()
 		var end_line:int = code_editor.get_selection_to_line()
-		code_editor.set_caret_line(start_line)
 		match code_placement:
 			AIQuickPromptResource.CodePlacement.BeforeSelection:
+				code_editor.set_caret_line(start_line)
+				text_answer = strip_empty_surrounding_lines(text_answer)
 				code_editor.insert_line_at(start_line, text_answer)
 			AIQuickPromptResource.CodePlacement.AfterSelection:
+				code_editor.set_caret_line(start_line)
+				text_answer = strip_empty_surrounding_lines(text_answer)
 				if end_line == code_editor.get_line_count() - 1: #it is at the end of the editor
 					code_editor.text += "\n%s" % text_answer
 				else:
 					code_editor.insert_line_at(end_line + 1, text_answer)
 			AIQuickPromptResource.CodePlacement.ReplaceSelection:
+				var column = code_editor.get_selection_from_column()
 				code_editor.delete_selection()
-				text_answer = text_answer.trim_suffix("\n")
+				text_answer = strip_empty_surrounding_lines(text_answer)
 				code_editor.insert_text_at_caret(text_answer)
 			_:
 				push_error("Unexpected Quick Prompt code placement value: %s" % code_placement)
@@ -36,3 +40,12 @@ func write_to_code_editor(text_answer:String, code_placement:AIQuickPromptResour
 		code_editor.select(start_line, 0, start_line, 0)
 		return true
 	return false
+
+
+func strip_empty_surrounding_lines(text:String) -> String:
+	var lines:PackedStringArray = text.split("\n")
+	while not lines.is_empty() and lines[0].is_empty():
+		lines.remove_at(0)
+	while not lines.is_empty() and lines[lines.size() - 1].is_empty():
+		lines.remove_at(lines.size() - 1)
+	return "\n".join(lines)

--- a/addons/ai_assistant_hub/tools/assistant_tool_selection.gd
+++ b/addons/ai_assistant_hub/tools/assistant_tool_selection.gd
@@ -79,21 +79,20 @@ func back_to_selection() -> bool:
 	if _selected_code.is_empty():
 		return false
 	
-	#double check the script to edit is still open, if it's not open it
-	var editor_interface:EditorInterface = _plugin.get_editor_interface()
-	var curr_script:Script = editor_interface.get_script_editor().get_current_script()
+	#double check the script to edit is still open, if it's not, open it
+	var curr_script:Script = EditorInterface.get_script_editor().get_current_script()
 	if curr_script != _selected_script:
 		#print("The script for the original request was: %s" % _selected_script.resource_path)
 		#print("The script currently opened is: %s" % curr_script.resource_path)
-		print("Opening %s" % _selected_script.resource_path)
-		editor_interface.edit_script(_selected_script)
+		print("AI Assistant Hub: Opening %s" % _selected_script.resource_path)
+		EditorInterface.edit_script(_selected_script)
 		forget_selection()
 	
-	var script_editor:= _plugin.get_editor_interface().get_script_editor()
+	var script_editor:= EditorInterface.get_script_editor()
 	var code_editor:TextEdit = script_editor.get_current_editor().get_base_editor()
 	var curr_selection: String = code_editor.get_selected_text()
 	if _selected_code != curr_selection:
-		print("The selection changed. Finding: %s" % _selected_code_first_line)
+		print("AI Assistant Hub: The selection changed. Finding: %s" % _selected_code_first_line)
 		var search_start:Vector2i = code_editor.search(_selected_code_first_line, TextEdit.SearchFlags.SEARCH_MATCH_CASE, 0, 0)
 		if search_start.x == -1:
 			return false
@@ -107,7 +106,7 @@ func back_to_selection() -> bool:
 				#print("Last line found.")
 				var line_diff = search_end.y - search_start.y
 				if original_line_diff == line_diff:
-					code_editor.select(search_start.y, search_start.x, search_end.y, _selected_code_line_end_column)
+					code_editor.select(search_start.y, _selected_code_line_start_column, search_end.y, _selected_code_line_end_column)
 				else:
 					return false
 	return true

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,12 @@
 **Version history**
 --------------------
 
+**1.8.1**
+* When you select an assistant tab, the chat text box is now focused automatically.
+* Added commented code in ai_hub_plugin.gd under _enter_tree() and _exit_tree(), in Godot 4.6 you can uncomment this to enable making the plugin screen floating by right-clicking its tab.
+* Fixed bugs in code placement when replacing the selection. Also improved code placement in general removing extra lines around it.
+* Fixed bug that caused freeze when editing an assistant resource in Linux.
+
 **1.8.0**
 * xAI API support
 


### PR DESCRIPTION
* When you select an assistant tab, the chat text box is now focused automatically.
* Added commented code in ai_hub_plugin.gd under _enter_tree() and _exit_tree(), in Godot 4.6 you can uncomment this to enable making the plugin screen floating by right-clicking its tab. This is related to #64 
* Fixed bugs in code placement when replacing the selection. Also improved code placement in general removing extra lines around it.
* Fixed bug that caused freeze when editing an assistant resource in Linux. Fixes #60.